### PR TITLE
Reduce polling interval from 1s to 3s across panel

### DIFF
--- a/src/hooks/use-cron-job.ts
+++ b/src/hooks/use-cron-job.ts
@@ -26,7 +26,7 @@ export default function useCronJob() {
     }
 
     loadCronJob();
-    const interval = window.setInterval(loadCronJob, 1000);
+    const interval = window.setInterval(loadCronJob, 3000);
     return () => { isMounted = false; clearInterval(interval); };
   }, [searchParams]);
 

--- a/src/hooks/use-daemon-set.ts
+++ b/src/hooks/use-daemon-set.ts
@@ -26,7 +26,7 @@ export default function useDaemonSet() {
     }
 
     loadDaemonSet();
-    const interval = window.setInterval(loadDaemonSet, 1000);
+    const interval = window.setInterval(loadDaemonSet, 3000);
     return () => { isMounted = false; clearInterval(interval); };
   }, [searchParams]);
 

--- a/src/hooks/use-deployment.ts
+++ b/src/hooks/use-deployment.ts
@@ -26,7 +26,7 @@ export default function useDeployment() {
     }
 
     loadDeployment();
-    const interval = window.setInterval(loadDeployment, 1000);
+    const interval = window.setInterval(loadDeployment, 3000);
     return () => { isMounted = false; clearInterval(interval); };
   }, [searchParams]);
 

--- a/src/hooks/use-node.ts
+++ b/src/hooks/use-node.ts
@@ -25,7 +25,7 @@ export default function useNode() {
     }
 
     loadNode();
-    const interval = window.setInterval(loadNode, 1000);
+    const interval = window.setInterval(loadNode, 3000);
     return () => { isMounted = false; clearInterval(interval); };
   }, [searchParams]);
 

--- a/src/hooks/use-pod.ts
+++ b/src/hooks/use-pod.ts
@@ -26,7 +26,7 @@ export default function usePod() {
     }
 
     loadPod();
-    const interval = window.setInterval(loadPod, 1000);
+    const interval = window.setInterval(loadPod, 3000);
     return () => { isMounted = false; clearInterval(interval); };
   }, [searchParams]);
 

--- a/src/hooks/use-replica-set.ts
+++ b/src/hooks/use-replica-set.ts
@@ -26,7 +26,7 @@ export default function useReplicaSet() {
     }
 
     loadReplicaSet();
-    const interval = window.setInterval(loadReplicaSet, 1000);
+    const interval = window.setInterval(loadReplicaSet, 3000);
     return () => { isMounted = false; clearInterval(interval); };
   }, [searchParams]);
 

--- a/src/hooks/use-stateful-set.ts
+++ b/src/hooks/use-stateful-set.ts
@@ -26,7 +26,7 @@ export default function useStatefulSet() {
     }
 
     loadStatefulSet();
-    const interval = window.setInterval(loadStatefulSet, 1000);
+    const interval = window.setInterval(loadStatefulSet, 3000);
     return () => { isMounted = false; clearInterval(interval); };
   }, [searchParams]);
 

--- a/src/layouts/panel/header/notification/sheet.tsx
+++ b/src/layouts/panel/header/notification/sheet.tsx
@@ -32,7 +32,7 @@ export default function NotificationSheet({cluster}: {cluster: boolean}) {
     };
 
     fetchNotifications();
-    const interval = setInterval(fetchNotifications, 1000);
+    const interval = setInterval(fetchNotifications, 3000);
     return () => clearInterval(interval);
   }, [cluster]);
 

--- a/src/pages/panel/cluster/index.tsx
+++ b/src/pages/panel/cluster/index.tsx
@@ -95,7 +95,7 @@ export default function ClusterPage() {
         })
       );
       setClusters(updatedClusters);
-    }, 1000);
+    }, 3000);
 
     return () => clearInterval(interval);
   }, [clusters]);

--- a/src/pages/panel/cron-jobs/index.tsx
+++ b/src/pages/panel/cron-jobs/index.tsx
@@ -88,7 +88,7 @@ export default function CronJobsPage() {
 
     loadCronJobs();
     loadNamespaces();
-    const interval = window.setInterval(loadCronJobs, 1000);
+    const interval = window.setInterval(loadCronJobs, 3000);
     return () => {
       clearInterval(interval);
     };

--- a/src/pages/panel/daemon-sets/index.tsx
+++ b/src/pages/panel/daemon-sets/index.tsx
@@ -85,7 +85,7 @@ export default function DaemonSetsPage() {
 
     loadDaemonSets();
     loadNamespaces();
-    const interval = window.setInterval(loadDaemonSets, 1000);
+    const interval = window.setInterval(loadDaemonSets, 3000);
     return () => {
       clearInterval(interval);
     };

--- a/src/pages/panel/deployments/index.tsx
+++ b/src/pages/panel/deployments/index.tsx
@@ -85,7 +85,7 @@ export default function DeploymentsPage() {
 
     loadDeployments();
     loadNamespaces();
-    const interval = window.setInterval(loadDeployments, 1000);
+    const interval = window.setInterval(loadDeployments, 3000);
     return () => {
       clearInterval(interval);
     };

--- a/src/pages/panel/events/index.tsx
+++ b/src/pages/panel/events/index.tsx
@@ -107,7 +107,7 @@ export default function EventsPage() {
     }
 
     loadEvents();
-    const interval = setInterval(loadEvents, 1000);
+    const interval = setInterval(loadEvents, 3000);
     return () => clearInterval(interval);
   }, [startDate, endDate, limit, selectedValues, search]);
 

--- a/src/pages/panel/namespaces/index.tsx
+++ b/src/pages/panel/namespaces/index.tsx
@@ -55,7 +55,7 @@ export default function NamespacesPage() {
   };
   useEffect(() => {
     loadNamespaces();
-    const interval = window.setInterval(loadNamespaces, 1000);
+    const interval = window.setInterval(loadNamespaces, 3000);
     return () => clearInterval(interval);
   }, []);
   if (!isLoading && namespaces.length === 0) {

--- a/src/pages/panel/nodes/index.tsx
+++ b/src/pages/panel/nodes/index.tsx
@@ -81,7 +81,7 @@ export default function NodesPage() {
       }
     }
     loadNodes();
-    const interval = window.setInterval(loadNodes, 1000);
+    const interval = window.setInterval(loadNodes, 3000);
     return () => {
       clearInterval(interval);
     };

--- a/src/pages/panel/overview/activity.tsx
+++ b/src/pages/panel/overview/activity.tsx
@@ -142,7 +142,7 @@ export default function OverviewActivityBox() {
 
     loadEvents();
 
-    const interval = setInterval(loadEvents, 1000);
+    const interval = setInterval(loadEvents, 3000);
     return () => clearInterval(interval);
   }, []);
 

--- a/src/pages/panel/overview/index.tsx
+++ b/src/pages/panel/overview/index.tsx
@@ -21,7 +21,7 @@ export default function OverviewPage() {
       }
     }
     loadNodes();
-    const interval = window.setInterval(loadNodes, 1000);
+    const interval = window.setInterval(loadNodes, 3000);
     return () => {
       clearInterval(interval);
     };

--- a/src/pages/panel/overview/news.tsx
+++ b/src/pages/panel/overview/news.tsx
@@ -48,7 +48,7 @@ export default function OverviewNewsBox() {
     };
 
     fetchNotifications();
-    const interval = setInterval(fetchNotifications, 1000);
+    const interval = setInterval(fetchNotifications, 3000);
     return () => clearInterval(interval);
   }, []);
 

--- a/src/pages/panel/pods/list.tsx
+++ b/src/pages/panel/pods/list.tsx
@@ -67,7 +67,7 @@ export default function PodsList(
 
     loadPods();
     loadNamespaces();
-    const interval = window.setInterval(loadPods, 1000);
+    const interval = window.setInterval(loadPods, 3000);
     return () => {
       clearInterval(interval);
     };

--- a/src/pages/panel/replica-sets/index.tsx
+++ b/src/pages/panel/replica-sets/index.tsx
@@ -90,7 +90,7 @@ export default function ReplicaSetsPage() {
 
     loadReplicaSets();
     loadNamespaces();
-    const interval = window.setInterval(loadReplicaSets, 1000);
+    const interval = window.setInterval(loadReplicaSets, 3000);
     return () => {
       clearInterval(interval);
     };

--- a/src/pages/panel/services/index.tsx
+++ b/src/pages/panel/services/index.tsx
@@ -87,7 +87,7 @@ export default function ServicesPage() {
 
     loadServices();
     loadNamespaces();
-    const interval = window.setInterval(loadServices, 1000);
+    const interval = window.setInterval(loadServices, 3000);
     return () => {
       clearInterval(interval);
     };

--- a/src/pages/panel/stateful-sets/index.tsx
+++ b/src/pages/panel/stateful-sets/index.tsx
@@ -85,7 +85,7 @@ export default function StatefulSetsPage() {
 
     loadStatefulSets();
     loadNamespaces();
-    const interval = window.setInterval(loadStatefulSets, 1000);
+    const interval = window.setInterval(loadStatefulSets, 3000);
     return () => {
       clearInterval(interval);
     };


### PR DESCRIPTION
The panel currently polls most resource endpoints every second (nodes, pods, deployments, services, notifications, events, etc.), which puts unnecessary load on the core API and database, especially noticeable on multi-node setups where each cluster is polled independently.

Pod logs remain at 1s since they need to feel real-time.