### PR TITLE
Fix sporadic logout bug

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -57,12 +57,8 @@ axiosInstance.interceptors.response.use(
   },
   async (error: AxiosError) => {
     const originalRequest = error.config as AuthenticationRequestConfig;
-    const {response} = error || {};
-    if (response?.status === 401) {
-      userStore.getState().actions.clearUserToken();
-      return Promise.reject(error);
-    }
-    if (response?.status === 417 && !originalRequest._retry) {
+    const status = error?.response?.status;
+    if ((status === 401 || status === 417) && !originalRequest._retry) {
       return refresh(originalRequest, error);
     }
     return Promise.reject(error);

--- a/src/routes/components/login-auth-guard.tsx
+++ b/src/routes/components/login-auth-guard.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from "react";
 import {useRouter} from "../hooks";
-import useUserStore, {useUserToken} from "@/store/user-store";
+import {useHasUserHydrated, useUserToken} from "@/store/user-store";
 
 type Props = {
   children: React.ReactNode;
@@ -9,7 +9,7 @@ export default function LoginAuthGuard({children}: Props) {
   const router = useRouter();
   const {authentication_token} = useUserToken();
 
-  const hasHydrated = useUserStore.persist.hasHydrated();
+  const hasHydrated = useHasUserHydrated();
 
   useEffect(() => {
     if (hasHydrated && !authentication_token) {

--- a/src/store/cookie-store.ts
+++ b/src/store/cookie-store.ts
@@ -1,16 +1,12 @@
 import type {StateStorage} from 'zustand/middleware';
 import {getCookie, removeCookie, setCookie} from 'typescript-cookie';
 
-const cookiesStorage: StateStorage = {
-  getItem: (name: string) => {
-    return getCookie(name) ?? null;
+export const cookieStorage = (expiry: number): StateStorage => ({
+  getItem: (name) => getCookie(name) ?? null,
+  setItem: (name, value) => {
+    setCookie(name, value, {expires: expiry, secure: true});
   },
-  setItem: (name: string, value: string) => {
-    setCookie(name, value, {expires: 1, secure: true});
-  },
-  removeItem: (name: string) => {
+  removeItem: (name) => {
     removeCookie(name);
-  }
-}
-
-export default cookiesStorage;
+  },
+});

--- a/src/store/user-store.ts
+++ b/src/store/user-store.ts
@@ -1,11 +1,15 @@
+import {useMemo} from "react";
 import {useMutation} from "@tanstack/react-query";
 import {create} from "zustand";
 import {createJSONStorage, persist} from "zustand/middleware";
 import userService, {type LoginRequest} from "@/api/services/user-service";
-import cookiesStorage from "@/store/cookie-store.ts";
+import {cookieStorage} from "@/store/cookie-store.ts";
 import {toast} from "sonner";
 import {useTranslation} from "react-i18next";
 import {useRouter} from "@/routes/hooks";
+
+const AUTH_COOKIE_EXPIRY = 1;
+const REFRESH_COOKIE_EXPIRY = 30;
 
 export interface UserToken {
   authentication_token?: string;
@@ -17,55 +21,122 @@ export interface UserInformation {
   name?: string;
 }
 
-type UserStore = {
-  token: UserToken;
+type AuthStore = {
+  authentication_token?: string;
   information: UserInformation;
-
   actions: {
-    setUserToken: (token: UserToken) => void;
-    clearUserToken: () => void;
-    setUserInformation: (token: UserInformation) => void;
-    clearUserInformation: () => void;
+    setAuthenticationToken: (token?: string) => void;
+    clearAuthenticationToken: () => void;
+    setInformation: (info: UserInformation) => void;
+    clearInformation: () => void;
   };
 };
 
-const useUserStore = create<UserStore>()(
+type RefreshStore = {
+  refresh_token?: string;
+  actions: {
+    setRefreshToken: (token?: string) => void;
+    clearRefreshToken: () => void;
+  };
+};
+
+const useAuthStore = create<AuthStore>()(
   persist(
     (set) => ({
-      token: {},
+      authentication_token: undefined,
       information: {},
-
       actions: {
-        setUserToken: (token) => {
-          set({ token });
-        },
-        clearUserToken() {
-          set({ token: {} });
-        },
-
-        setUserInformation: (info) => {
-          set({ information: info });
-        },
-        clearUserInformation() {
-          set({ information: {} });
-        },
+        setAuthenticationToken: (token) => set({authentication_token: token}),
+        clearAuthenticationToken: () => set({authentication_token: undefined}),
+        setInformation: (info) => set({information: info}),
+        clearInformation: () => set({information: {}}),
       },
     }),
     {
       name: "user",
-      storage: createJSONStorage(() => cookiesStorage),
-      partialize: (state) => ({
-        token: state.token,
-        information: state.information,
+      storage: createJSONStorage(() => cookieStorage(AUTH_COOKIE_EXPIRY)),
+      partialize: (s) => ({
+        authentication_token: s.authentication_token,
+        information: s.information,
       }),
     },
   ),
 );
 
-export const useUserToken = () => useUserStore((state) => state.token);
-export const useUserInformation = () =>
-  useUserStore((state) => state.information);
-export const useUserActions = () => useUserStore((state) => state.actions);
+const useRefreshStore = create<RefreshStore>()(
+  persist(
+    (set) => ({
+      refresh_token: undefined,
+      actions: {
+        setRefreshToken: (token) => set({refresh_token: token}),
+        clearRefreshToken: () => set({refresh_token: undefined}),
+      },
+    }),
+    {
+      name: "user-refresh",
+      storage: createJSONStorage(() => cookieStorage(REFRESH_COOKIE_EXPIRY)),
+      partialize: (s) => ({refresh_token: s.refresh_token}),
+    },
+  ),
+);
+
+export const useUserToken = (): UserToken => {
+  const authentication_token = useAuthStore((s) => s.authentication_token);
+  const refresh_token = useRefreshStore((s) => s.refresh_token);
+  return {authentication_token, refresh_token};
+};
+
+export const useUserInformation = () => useAuthStore((s) => s.information);
+
+export const useUserActions = () => {
+  const authActions = useAuthStore((s) => s.actions);
+  const refreshActions = useRefreshStore((s) => s.actions);
+  return useMemo(
+    () => ({
+      setUserToken: (token: UserToken) => {
+        authActions.setAuthenticationToken(token.authentication_token);
+        refreshActions.setRefreshToken(token.refresh_token);
+      },
+      clearUserToken: () => {
+        authActions.clearAuthenticationToken();
+        refreshActions.clearRefreshToken();
+      },
+      setUserInformation: authActions.setInformation,
+      clearUserInformation: authActions.clearInformation,
+    }),
+    [authActions, refreshActions],
+  );
+};
+
+export const useHasUserHydrated = () => {
+  const auth = useAuthStore.persist.hasHydrated();
+  const refresh = useRefreshStore.persist.hasHydrated();
+  return auth && refresh;
+};
+
+const userStore = {
+  getState: () => {
+    const auth = useAuthStore.getState();
+    const refresh = useRefreshStore.getState();
+    return {
+      token: {
+        authentication_token: auth.authentication_token,
+        refresh_token: refresh.refresh_token,
+      } as UserToken,
+      information: auth.information,
+      actions: {
+        setUserToken: (token: UserToken) => {
+          auth.actions.setAuthenticationToken(token.authentication_token);
+          refresh.actions.setRefreshToken(token.refresh_token);
+        },
+        clearUserToken: () => {
+          auth.actions.clearAuthenticationToken();
+          refresh.actions.clearRefreshToken();
+        },
+      },
+    };
+  },
+};
 
 export const useLogin = () => {
   const { t } = useTranslation();
@@ -115,4 +186,4 @@ export const useLogout = () => {
   };
 };
 
-export default useUserStore;
+export default userStore;


### PR DESCRIPTION
* Routes 401 through refresh path to avoid spurious logout

* Refactors cookie storage into expiry-parameterized factory

* Splits auth and refresh tokens into separate stores with distinct cookie TTLs

* Waits for both auth and refresh stores to hydrate before guarding
